### PR TITLE
Style login button bootstrap-style like other buttons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,14 @@ FROM eu.gcr.io/vseth-public/base:delta
 COPY cinit.yml /etc/cinit.d/tq-website.yml
 
 # Install python
-RUN apt install -y python3 python3-pip python3-setuptools
+RUN apt install -y python python3 python3-pip python3-setuptools
 
 # Install dependencies:
 # - git to clone code from Github
 # - libpq-dev to build psycopg2 (which in turn is needed for the connection to postgres)
 RUN apt install -y --no-install-recommends git libpq-dev
+
+RUN mkdir -p /app
 
 WORKDIR /app
 
@@ -34,6 +36,9 @@ RUN mkdir -p logs && \
     touch logs/tq.log && \
     touch logs/payments.log && \
     touch logs/errors.log
+
+RUN mkdir -p ~/.aws
+RUN echo "[default]\nregion=europe-west-2" > ~/.aws/config
 
 # Change permissions on the code so the app-user can access it
 RUN chown -R app-user:app-user .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM eu.gcr.io/vseth-public/base:delta
 COPY cinit.yml /etc/cinit.d/tq-website.yml
 
 # Install python
-RUN apt install -y python python3 python3-pip python3-setuptools
+RUN apt install -y python3 python3-pip python3-setuptools
 
 # Install dependencies:
 # - git to clone code from Github

--- a/scripts/initialize_minio.py
+++ b/scripts/initialize_minio.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-
 import os
 import json
 
 from minio import Minio
-from minio.error import BucketAlreadyOwnedByYou
+from minio.error import MinioException
 
 from dotenv import load_dotenv
 load_dotenv()
@@ -21,21 +20,21 @@ try:
     print('creating media bucket')
     minio_client.make_bucket(os.environ.get('TQ_S3_MEDIA_BUCKET'),
                              location=os.environ.get('TQ_S3_MEDIA_REGION'))
-except BucketAlreadyOwnedByYou:
+except MinioException:
     pass
 
 try:
     print('creating static bucket')
     minio_client.make_bucket(os.environ.get('TQ_S3_STATIC_BUCKET'),
                              location=os.environ.get('TQ_S3_STATIC_REGION'))
-except BucketAlreadyOwnedByYou:
+except MinioException:
     pass
 
 try:
     print('creating postfinance bucket')
     minio_client.make_bucket(os.environ.get('TQ_S3_POSTFINANCE_BUCKET'),
                              location=os.environ.get('TQ_S3_POSTFINANCE_REGION'))
-except BucketAlreadyOwnedByYou:
+except MinioException:
     pass
 
 print('configure static bucket')

--- a/scripts/initialize_minio.sh
+++ b/scripts/initialize_minio.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker-compose run --rm django python "scripts/initialize_minio.py"
+docker-compose run --rm django python3 "scripts/initialize_minio.py"

--- a/scripts/loaddata.sh
+++ b/scripts/loaddata.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker-compose run --rm django python manage.py loaddata fixtures/*
+docker-compose run --rm django python3 manage.py loaddata fixtures/*

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,0 +1,46 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% load account socialaccount %}
+
+{% block head_title %}{% trans "Sign In" %}{% endblock %}
+
+{% block content %}
+
+<h1>{% trans "Sign In" %}</h1>
+
+{% get_providers as socialaccount_providers %}
+
+{% if socialaccount_providers %}
+<p>{% blocktrans with site.name as site_name %}Please sign in with one
+of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
+for a {{ site_name }} account and sign in below:{% endblocktrans %}</p>
+
+<div class="socialaccount_ballot">
+
+  <ul class="socialaccount_providers">
+    {% include "socialaccount/snippets/provider_list.html" with process="login" %}
+  </ul>
+
+  <div class="login-or">{% trans 'or' %}</div>
+
+</div>
+
+{% include "socialaccount/snippets/login_extra.html" %}
+
+{% else %}
+<p>{% blocktrans %}If you have not created an account yet, then please
+<a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</p>
+{% endif %}
+
+<form class="login" method="POST" action="{% url 'account_login' %}">
+  {% csrf_token %}
+  {{ form.as_p }}
+  {% if redirect_field_value %}
+  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+  {% endif %}
+  <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+  <button class="primaryAction btn btn-primary" type="submit">{% trans "Sign In" %}</button>
+</form>
+
+{% endblock %}


### PR DESCRIPTION
This is a minor change by me just exploring the code in this repo. In essence, I copied the source login html from [django-allauth](https://github.com/pennersr/django-allauth/blob/master/allauth/templates/account/login.html) to add the bootstrap `btn btn-primary` classes. There are of course numerous other possibilities to achive the same, but I guess this is the most straight-forward.

The change looks like this:

![tanzq_before_after](https://user-images.githubusercontent.com/8596965/134395732-1873dc09-ad4e-41f5-a046-20228c97572e.png)

Apart from this minor visual change, I also adjusted one or two things that broke the Docker setup for me — if you want, I can split those into a separate PR. 