### PR TITLE
Case insensitive check for partner

### DIFF
--- a/courses/forms/subscribe_form.py
+++ b/courses/forms/subscribe_form.py
@@ -115,7 +115,7 @@ class SubscribeForm(forms.Form):
                     self.add_error("partner_email", error)
                     return cleaned_data
 
-                partner = User.objects.get(email=partner_email)
+                partner = User.objects.filter(email=partner_email).first()
                 if partner is None and User.objects.filter(email__iexact=partner_email).count() > 1:
                     error = ValidationError(
                         message=_(

--- a/courses/forms/subscribe_form.py
+++ b/courses/forms/subscribe_form.py
@@ -115,7 +115,7 @@ class SubscribeForm(forms.Form):
                     self.add_error("partner_email", error)
                     return cleaned_data
 
-                partner = User.objects.get(email=partner_email)
+                partner = User.objects.get(email__iexact=partner_email)
 
                 if self.user == partner:
                     error = ValidationError(

--- a/courses/forms/subscribe_form.py
+++ b/courses/forms/subscribe_form.py
@@ -125,7 +125,7 @@ class SubscribeForm(forms.Form):
                     )
                     self.add_error("partner_email", error)
                     return cleaned_data
-                else:
+                elif partner is None:
                     partner = User.objects.get(email__iexact=partner_email)
 
                 if self.user == partner:

--- a/courses/forms/subscribe_form.py
+++ b/courses/forms/subscribe_form.py
@@ -105,7 +105,7 @@ class SubscribeForm(forms.Form):
                     self.add_error("partner_email", error)
                     return cleaned_data
 
-                if not User.objects.filter(email=partner_email).exists():
+                if not User.objects.filter(email__iexact=partner_email).exists(): # iexact: case insensitive
                     error = ValidationError(
                         message=_(
                             "No user found with this email address. Please make sure your partner has an account"

--- a/courses/forms/subscribe_form.py
+++ b/courses/forms/subscribe_form.py
@@ -115,7 +115,18 @@ class SubscribeForm(forms.Form):
                     self.add_error("partner_email", error)
                     return cleaned_data
 
-                partner = User.objects.get(email__iexact=partner_email)
+                partner = User.objects.get(email=partner_email)
+                if partner is None and User.objects.filter(email__iexact=partner_email).count() > 1:
+                    error = ValidationError(
+                        message=_(
+                            "Please check the upper/lower casing of this email address."
+                        ),
+                        code="multiple users for partner email",
+                    )
+                    self.add_error("partner_email", error)
+                    return cleaned_data
+                else:
+                    partner = User.objects.get(email__iexact=partner_email)
 
                 if self.user == partner:
                     error = ValidationError(


### PR DESCRIPTION
If the case of the entered email (e.g., copied from a message, so the first character may be upper cased by accident) did not match, previously the partner could not be confirmed. 
As emails will not collide apart from casing, the casing collision is handled separately. 
One could though argue that this specific error message does not reconcile with data protection / privacy. 